### PR TITLE
Add seed shutdown workaround

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,8 +115,9 @@ above and have already logged in (e.g. ``ssh centos@<ip>``).
    # Clone the Tenks repository.
    git clone https://git.openstack.org/openstack/tenks.git
 
-   # Shutdown the seed VM.
-   sudo virsh shutdown seed
+   # Shutdown the seed VM. virsh shutdown doesn't work due to the lack of ACPI
+   ssh centos@192.168.33.5 shutdown -h now
+   sleep 60 && sudo virsh destroy seed
 
 If required, add any additional SSH public keys to /home/centos/.ssh/authorized_keys
 


### PR DESCRIPTION
Lack of ACPI in guest XML means that virsh shutdown has no effect. As a
workaround, call shutdown from inside the guest before using virsh
destroy (immediate ungraceful shutdown).