### PR TITLE
Use upstream kolla-ansible (stable/train)

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -38,12 +38,10 @@
 # URL of Kolla Ansible source code repository if type is 'source'. Default is
 # https://opendev.org/openstack/kolla-ansible.
 #kolla_ansible_source_url:
-kolla_ansible_source_url: https://github.com/stackhpc/kolla-ansible
 
 # Version (branch, tag, etc.) of Kolla Ansible source code repository if type
 # is 'source'. Default is {{ openstack_branch }}.
 #kolla_ansible_source_version:
-kolla_ansible_source_version: a-universe-from-nothing/train
 
 # Path to virtualenv in which to install kolla-ansible. Default is
 # $KOLLA_VENV_PATH or $PWD/venvs/kolla-ansible if $KOLLA_VENV_PATH is not set.


### PR DESCRIPTION
The issue with docker client timeouts that required a fork of kolla-ansible is
now resolved upstream