### PR TITLE
Use upstream kolla-ansible

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -34,12 +34,10 @@
 
 # URL of Kolla Ansible source code repository if type is 'source'.
 #kolla_ansible_source_url:
-kolla_ansible_source_url: https://github.com/stackhpc/kolla-ansible
 
 # Version (branch, tag, etc.) of Kolla Ansible source code repository if type
 # is 'source'.
 #kolla_ansible_source_version:
-kolla_ansible_source_version: a-universe-from-nothing/rocky
 
 # Path to virtualenv in which to install kolla-ansible.
 #kolla_ansible_venv:


### PR DESCRIPTION
The issue with docker client timeouts that required a fork of kolla-ansible is
now resolved upstream