### PR TITLE
Install OpenStack clients using upper constraints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -534,7 +534,7 @@ OpenStack venv:
     . ~/os-venv/bin/activate
 
     # Install barbicanclient
-    pip install python-barbicanclient
+    pip install python-barbicanclient -c https://releases.openstack.org/constraints/upper/train
 
     # Source the OpenStack environment variables
     source ~/kayobe/config/src/kayobe-config/etc/kolla/public-openrc.sh

--- a/init-runonce.sh
+++ b/init-runonce.sh
@@ -6,7 +6,7 @@ if [[ ! -d ~/os-venv ]]; then
   virtualenv ~/os-venv
 fi
 ~/os-venv/bin/pip install -U pip
-~/os-venv/bin/pip install python-openstackclient
+~/os-venv/bin/pip install python-openstackclient -c https://releases.openstack.org/constraints/upper/train
 
 parent="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 init_runonce=$parent/../kolla-ansible/tools/init-runonce


### PR DESCRIPTION
This will be particularly useful once backported to stable branches
using Python 2, as latest client versions only support Python 3.

(cherry picked from commit 2325e9c024236937570f1b0727f11613fa7e0b13)