### PR TITLE
Update seed VM shutdown instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,9 +135,7 @@ necessary `Preparation`_.
    ./config/src/kayobe-config/configure-local-networking.sh
 
    # Optional: Shutdown the seed VM if creating a seed snapshot.
-   # virsh shutdown doesn't work due to the lack of ACPI
-   ssh centos@192.168.33.5 shutdown -h now
-   sleep 60 && sudo virsh destroy seed
+   sudo virsh shutdown seed
 
 If required, add any additional SSH public keys to /home/centos/.ssh/authorized_keys
 


### PR DESCRIPTION
The `virsh shutdown` command works fine when Kayobe uses a recent version of the libvirt-vm role.

(cherry picked from commit 0a685a77b9c9d8b478fd2ac7794cd242f283e315)