### PR TITLE
CentOS 8: update README and scripts (Train)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ There are four parts to this guide:
 exercise, and fetching the necessary source code.
 
 *Deploying a Seed* includes all instructions necessary to download and
-install the Kayobe prerequisites on a plain CentOS 7 cloud image, including
+install the Kayobe prerequisites on a plain CentOS 8 cloud image, including
 provisioning and configuration of a seed VM. Optionally, snapshot the
 instance after this step to reduce setup time in future.
 
@@ -77,14 +77,17 @@ above and have already logged in (e.g. ``ssh centos@<ip>``).
 
 .. code-block:: console
 
-   # Install git and screen.
-   sudo yum -y install git screen
+   # Install git and tmux.
+   sudo dnf -y install git tmux
 
    # Disable the firewall.
    sudo systemctl is-enabled firewalld && sudo systemctl stop firewalld && sudo systemctl disable firewalld
 
-   # Optional: start a new screen session in case we lose our connection.
-   screen -drR
+   # Disable SELinux.
+   sudo setenforce 0
+
+   # Optional: start a new tmux session in case we lose our connection.
+   tmux
 
    # Clone Kayobe.
    git clone https://opendev.org/openstack/kayobe.git -b stable/train
@@ -161,8 +164,8 @@ Otherwise, continue working with the instance from `Deploying a Seed`_.
 
 .. code-block:: console
 
-   # Optional: start a new screen session in case we lose our connection.
-   screen -drR
+   # Optional: start a new tmux session in case we lose our connection.
+   tmux
 
    # Set working directory
    cd ~/kayobe
@@ -180,18 +183,6 @@ is present and running.
 
    # Start up the seed VM if it is shut off.
    sudo virsh start seed
-
-*NOTE*: before starting the deploy of TENKS, make sure that an ``openvswitch``
-RPM is available for download.  If you're basing on CentOS 7.7, an additional
-repo is required for installation and setup of ``openvswitch``, and the RDO
-repo for Train is a good option:
-
-.. code-block:: console
-
-   sudo yum install -y centos-release-openstack-train
-   sudo yum install -y openvswitch
-   sudo systemctl enable openvswitch
-   sudo systemctl start openvswitch
 
 We use the `TENKS project <https://www.stackhpc.com/tenks.html>`_ to model
 some 'bare metal' VMs for the controller and compute node.  Here we set up

--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ above and have already logged in (e.g. ``ssh centos@<ip>``).
 
    # Install kayobe.
    cd ~/kayobe
-   ./dev/install.sh
+   ./dev/install-dev.sh
 
 Deploying a Seed
 ----------------

--- a/a-universe-from-nothing.sh
+++ b/a-universe-from-nothing.sh
@@ -5,9 +5,21 @@
 
 set -eu
 
+# Install git and tmux.
+sudo dnf -y install git tmux
+
+# Disable the firewall.
+sudo systemctl is-enabled firewalld && sudo systemctl stop firewalld && sudo systemctl disable firewalld
+
+# Disable SELinux.
+sudo setenforce 0
+
 # Clone Kayobe.
 [[ -d kayobe ]] || git clone https://git.openstack.org/openstack/kayobe.git -b stable/train
 cd kayobe
+
+# Clone the Tenks repository.
+[[ -d tenks ]] || git clone https://git.openstack.org/openstack/tenks.git
 
 # Clone this Kayobe configuration.
 mkdir -p config/src
@@ -19,7 +31,7 @@ cd config/src/
 
 # Install kayobe.
 cd ~/kayobe
-./dev/install.sh
+./dev/install-dev.sh
 
 # Deploy hypervisor services.
 ./dev/seed-hypervisor-deploy.sh
@@ -37,15 +49,6 @@ fi
 # Deploying the seed restarts networking interface,
 # run configure-local-networking.sh again to re-add routes.
 ./config/src/kayobe-config/configure-local-networking.sh
-
-# Clone the Tenks repository.
-[[ -d tenks ]] || git clone https://git.openstack.org/openstack/tenks.git
-
-# Install Open vSwitch for Tenks.
-sudo yum install -y centos-release-openstack-train
-sudo yum install -y openvswitch
-sudo systemctl enable openvswitch
-sudo systemctl start openvswitch
 
 # NOTE: Make sure to use ./tenks, since just ‘tenks’ will install via PyPI.
 export TENKS_CONFIG_PATH=config/src/kayobe-config/tenks.yml

--- a/configure-local-networking.sh
+++ b/configure-local-networking.sh
@@ -26,6 +26,11 @@ forwarded_ports="80 6080"
 # IP of the seed hypervisor on the OpenStack 'public' network created by init-runonce.sh.
 public_ip="10.0.2.1"
 
+# Install iptables.
+if $(which dnf >/dev/null 2>&1); then
+    sudo dnf -y install iptables
+fi
+
 # Configure local networking.
 # Add a bridge 'braio' for the Kayobe all-in-one cloud network.
 if ! sudo ip l show braio >/dev/null 2>&1; then

--- a/etc/kayobe/kolla/config/bifrost/bifrost.yml
+++ b/etc/kayobe/kolla/config/bifrost/bifrost.yml
@@ -3,6 +3,6 @@
 create_ipa_image: false
 download_ipa: true
 
-# Use a locally hosted CentOS7 cloud image.
+# Use a locally hosted CentOS8 cloud image.
 use_cirros: true
-cirros_deploy_image_upstream_url: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
+cirros_deploy_image_upstream_url: https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2

--- a/etc/kayobe/seed-vm.yml
+++ b/etc/kayobe/seed-vm.yml
@@ -27,7 +27,7 @@ seed_vm_vcpus: 1
 
 # Base image for the seed VM root volume.
 #seed_vm_root_image:
-seed_vm_root_image: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
+seed_vm_root_image: https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2
 
 # Capacity of the seed VM data volume.
 #seed_vm_data_capacity:

--- a/tenks.yml
+++ b/tenks.yml
@@ -45,5 +45,7 @@ nova_flavors: []
 physnet_mappings:
   physnet1: braio
 
+bridge_type: linuxbridge
+
 # No placement service.
 wait_for_placement: false


### PR DESCRIPTION
Using a separate stable/train-centos8 branch, rather than trying to include both paths in one.