### PR TITLE
Disable SELinux permanently

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,8 +85,9 @@ above and have already logged in (e.g. ``ssh centos@<ip>``).
    # Disable the firewall.
    sudo systemctl is-enabled firewalld && sudo systemctl stop firewalld && sudo systemctl disable firewalld
 
-   # Disable SELinux.
+   # Disable SELinux both immediately and permanently.
    sudo setenforce 0
+   sudo sed -i 's/^SELINUX=enforcing/SELINUX=disabled/' /etc/selinux/config
 
    # Optional: start a new tmux session in case we lose our connection.
    tmux

--- a/a-universe-from-nothing.sh
+++ b/a-universe-from-nothing.sh
@@ -11,8 +11,9 @@ sudo dnf -y install git tmux
 # Disable the firewall.
 sudo systemctl is-enabled firewalld && sudo systemctl stop firewalld && sudo systemctl disable firewalld
 
-# Disable SELinux.
+# Disable SELinux both immediately and permanently.
 sudo setenforce 0
+sudo sed -i 's/^SELINUX=enforcing/SELINUX=disabled/' /etc/selinux/config
 
 # Clone Kayobe.
 [[ -d kayobe ]] || git clone https://git.openstack.org/openstack/kayobe.git -b master


### PR DESCRIPTION
If SELinux is not disabled permanently, the seed VM won't start after reboot or boot from snapshot.

Closes #51.