### PR TITLE
Prevent Docker from manipulating iptables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -229,15 +229,6 @@ VM:
    source config/src/kayobe-config/etc/kolla/public-openrc.sh
    ./config/src/kayobe-config/init-runonce.sh
 
-We also need to relax iptables policies that are changed by Docker, which
-prevent traffic from reaching instances. You may need to rerun this command if
-Docker reverts the FORWARD policy to DENY again. A proper fix will be
-integrated soon.
-
-.. code-block:: console
-
-   kayobe overcloud host command run --command "iptables -P FORWARD ACCEPT" --become --limit controllers
-
 Following the instructions displayed by the above script, boot a VM.
 You'll need to have activated the `~/os-venv` virtual environment.
 

--- a/a-universe-from-nothing.sh
+++ b/a-universe-from-nothing.sh
@@ -68,6 +68,5 @@ kayobe overcloud container image pull
 kayobe overcloud service deploy
 source config/src/kayobe-config/etc/kolla/public-openrc.sh
 kayobe overcloud post configure
-kayobe overcloud host command run --command "iptables -P FORWARD ACCEPT" --become --limit controllers
 source config/src/kayobe-config/etc/kolla/public-openrc.sh
 ./config/src/kayobe-config/init-runonce.sh

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -7,3 +7,7 @@ nova_compute_virt_type: qemu
 # Reduce the control plane's memory footprint by limiting the number of worker
 # processes to one per-service.
 openstack_service_workers: "1"
+
+# Prevent Docker from manipulating iptables. Docker changes the default policy
+# on the FORWARD chain, which prevents traffic from reaching instances.
+docker_disable_default_iptables_rules: true


### PR DESCRIPTION
Use built-in support in Kolla Ansible for preventing Docker from manipulating iptables, to avoid connectivity issues with instances.