### PR TITLE
Fix pull-retag-push-images.sh when called without arguments

### DIFF
--- a/pull-retag-push-images.sh
+++ b/pull-retag-push-images.sh
@@ -11,4 +11,4 @@ fi
 
 cd ${KAYOBE_PATH}
 source dev/environment-setup.sh
-kayobe playbook run ${KAYOBE_CONFIG_PATH}/ansible/pull-retag-push.yml "${KAYOBE_EXTRA_ARGS}"
+kayobe playbook run ${KAYOBE_CONFIG_PATH}/ansible/pull-retag-push.yml ${KAYOBE_EXTRA_ARGS:+"$KAYOBE_EXTRA_ARGS"}


### PR DESCRIPTION
When called without arguments, this script runs Kayobe like this:

    kayobe playbook run ${KAYOBE_CONFIG_PATH}/ansible/pull-retag-push.yml ''

The extra '' argument causes the following error:

    Kayobe playbook  is invalid: Path does not exist

This commit only includes this argument if it is non-empty.

Closes #60.