### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/etc/kayobe/ansible/pull-retag-push.yml
+++ b/etc/kayobe/ansible/pull-retag-push.yml
@@ -32,8 +32,8 @@
       file:
         path: "{{ kolla_build_log_path }}"
         state: touch
-        owner: "{{ ansible_user_uid }}"
-        group: "{{ ansible_user_gid }}"
+        owner: "{{ ansible_facts.user_uid }}"
+        group: "{{ ansible_facts.user_gid }}"
       become: True
 
     - name: Login to docker registry


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars