### PR TITLE
Remove pause after interface bounce

### DIFF
--- a/etc/kayobe/networks.yml
+++ b/etc/kayobe/networks.yml
@@ -116,10 +116,5 @@ aio_mtu: 1450
 #network_route_tables:
 
 ###############################################################################
-# MichaelRigart interfaces configuration.
-
-interfaces_pause_time: 5
-
-###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes


### PR DESCRIPTION
This was necessary when using MichaelRigart.interfaces on Ubuntu, but
now we use stackhpc.systemd_networkd.