### PR TITLE
Drop override of docker_disable_default_iptables_rules

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -7,7 +7,3 @@ nova_compute_virt_type: qemu
 # Reduce the control plane's memory footprint by limiting the number of worker
 # processes to one per-service.
 openstack_service_workers: "1"
-
-# Prevent Docker from manipulating iptables. Docker changes the default policy
-# on the FORWARD chain, which prevents traffic from reaching instances.
-docker_disable_default_iptables_rules: true


### PR DESCRIPTION
True is the default from Wallaby