### PR TITLE
Use kolla_{external,internal}_vip_address instead of aio_vip_address

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -426,7 +426,7 @@ kolla_install_type: source
 
 # Virtual IP address of OpenStack internal API. Default is the vip_address
 # attribute of the internal network.
-#kolla_internal_vip_address:
+kolla_internal_vip_address: 192.168.33.2
 
 # Fully Qualified Domain Name (FQDN) of OpenStack internal API. Default is the
 # fqdn attribute of the internal network if set, otherwise
@@ -435,7 +435,7 @@ kolla_install_type: source
 
 # Virtual IP address of OpenStack external API. Default is the vip_address
 # attribute of the external network.
-#kolla_external_vip_address:
+kolla_external_vip_address: 192.168.33.2
 
 # Fully Qualified Domain Name (FQDN) of OpenStack external API. Default is the
 # fqdn attribute of the external network if set, otherwise

--- a/etc/kayobe/networks.yml
+++ b/etc/kayobe/networks.yml
@@ -88,7 +88,6 @@ aio_neutron_allocation_pool_start: 192.168.33.31
 aio_neutron_allocation_pool_end: 192.168.33.127
 aio_inspection_allocation_pool_start: 192.168.33.128
 aio_inspection_allocation_pool_end: 192.168.33.254
-aio_vip_address: 192.168.33.2
 aio_mtu: 1450
 
 ###############################################################################


### PR DESCRIPTION
The kolla_external_vip_address and kolla_internal_vip_address variables
were added in Wallaby, and the vip_address attribute is now deprecated.