### PR TITLE
Fix calling the pull-retag-push-images script

### DIFF
--- a/pull-retag-push-images.sh
+++ b/pull-retag-push-images.sh
@@ -9,6 +9,11 @@ if [[ -n $1 ]]; then
     KAYOBE_EXTRA_ARGS="-e container_image_regexes=\"$@\""
 fi
 
+# Shift arguments so they are not passed to environment-setup.sh when sourced,
+# which would break kayobe-env. See https://unix.stackexchange.com/a/151896 for
+# details.
+shift $#
+
 cd ${KAYOBE_PATH}
 source dev/environment-setup.sh
 kayobe playbook run ${KAYOBE_CONFIG_PATH}/ansible/pull-retag-push.yml ${KAYOBE_EXTRA_ARGS:+"$KAYOBE_EXTRA_ARGS"}


### PR DESCRIPTION
We need to shift command-line arguments, otherwise they are passed to
dev/environment-setup.sh and then to kayobe-env, with the following
failure:

    Using Kayobe config from /home/centos/kayobe/config/src/kayobe-config
    usage: /home/centos/kayobe/config/src/kayobe-config/kayobe-env [--environment <env-name>]