### PR TITLE
Increase capacity of controller node

### DIFF
--- a/tenks.yml
+++ b/tenks.yml
@@ -9,7 +9,7 @@ node_types:
     volumes:
       # There is a minimum disk space capacity requirement of 4GiB when using Ironic Python Agent:
       # https://github.com/openstack/ironic-python-agent/blob/master/ironic_python_agent/utils.py#L290
-      - capacity: 20GiB
+      - capacity: 40GiB
     physical_networks:
       - physnet1
     console_log_enabled: true


### PR DESCRIPTION
This PR will increase the disk size of the controller node by default from 20G to 40G as the 20G is very often quickly filled up leading to services such as docker crashing