### PR TITLE
Fix user error on SMS

### DIFF
--- a/etc/kayobe/seed-hypervisor.yml
+++ b/etc/kayobe/seed-hypervisor.yml
@@ -4,7 +4,7 @@
 
 # User with which to access the seed hypervisor via SSH during bootstrap, in
 # order to setup the Kayobe user account. Default is {{ os_distribution }}.
-#seed_hypervisor_bootstrap_user:
+seed_hypervisor_bootstrap_user: "{{ lookup('env', 'USER') }}"
 
 ###############################################################################
 # Seed hypervisor network interface configuration.


### PR DESCRIPTION
Switching the seed hypervisor bootstrap user to $USER because SMS uses cloud-user rather than centos