### PR TITLE
Increase resource capacity for lab controller

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,10 +20,10 @@ Requirements
 
 For this workshop we require the use of a single server, configured as a
 *seed hypervisor*. This server should be a bare metal node or VM running
-CentOS 8, with the following minimum requirements:
+CentOS Stream 8 or Ubuntu 20.04, with the following minimum requirements:
 
-* 32GB RAM
-* 80GB disk
+* 64GB RAM (more is recommended when growing the lab deployment)
+* 100GB disk
 
 We will also need SSH access to the seed hypervisor, and passwordless sudo
 configured for the login user.
@@ -75,7 +75,8 @@ Preparation
 
 This shows how to prepare the seed hypervisor for the exercise. It assumes
 you have created a seed hypervisor instance fitting the requirements
-above and have already logged in (e.g. ``ssh centos@<ip>``).
+above and have already logged in (e.g. ``ssh centos@<ip>``
+or ``ssh ubuntu@<ip>``).
 
 .. code-block:: console
 

--- a/tenks.yml
+++ b/tenks.yml
@@ -4,12 +4,12 @@
 
 node_types:
   controller:
-    memory_mb: 8192
+    memory_mb: 16384
     vcpus: 4
     volumes:
       # There is a minimum disk space capacity requirement of 4GiB when using Ironic Python Agent:
       # https://github.com/openstack/ironic-python-agent/blob/master/ironic_python_agent/utils.py#L290
-      - capacity: 20GiB
+      - capacity: 40GiB
     physical_networks:
       - physnet1
     console_log_enabled: true


### PR DESCRIPTION
Our standard lab resources are bigger than they once were.  When running a lab spread over several weeks, it is a frequent occurrence for the controller node to run out of disk or RAM.  This leads to oom-killer, filesystem overflow and other instability we can do without.  Increase both here.

Extends work done on PR https://github.com/stackhpc/a-universe-from-nothing/pull/130