### PR TITLE
update centos image

### DIFF
--- a/etc/kayobe/kolla/config/bifrost/bifrost.yml
+++ b/etc/kayobe/kolla/config/bifrost/bifrost.yml
@@ -8,5 +8,5 @@ use_cirros: true
 {% if os_distribution == 'ubuntu' %}
 cirros_deploy_image_upstream_url: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
 {% else %}
-cirros_deploy_image_upstream_url: "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20210210.0.x86_64.qcow2"
+cirros_deploy_image_upstream_url: "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230501.0.x86_64.qcow2"
 {% endif %}

--- a/init-runonce.sh
+++ b/init-runonce.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [[ ! -d ~/os-venv ]]; then
-  virtualenv ~/os-venv
+  python3 -m venv ~/os-venv
 fi
 ~/os-venv/bin/pip install -U pip
 ~/os-venv/bin/pip install python-openstackclient -c https://releases.openstack.org/constraints/upper/yoga


### PR DESCRIPTION
The old image appears to have been removed:
https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20210210.0.x86_64.qcow2 Updated with a new image from 2023:
https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230501.0.x86_64.qcow2