### PR TITLE
Disable libvirt_vm_trust_guest_rx_filters

### DIFF
--- a/tenks.yml
+++ b/tenks.yml
@@ -49,3 +49,9 @@ bridge_type: linuxbridge
 
 # No placement service.
 wait_for_placement: false
+
+# NOTE(priteau): Disable libvirt_vm_trust_guest_rx_filters, which when enabled
+# triggers the following errors when booting baremetal instances with Tenks on
+# Libvirt 9: Cannot set interface flags on 'macvtap1': Value too large for
+# defined data type
+libvirt_vm_trust_guest_rx_filters: false


### PR DESCRIPTION
This works around failures to boot baremetal instances with Tenks after their deployment with Ironic is complete. See the upstream Kayobe change for more details [1].

While this may break multicast traffic [2], it allows a Universe from Nothing on Rocky Linux 9 to complete and the CirrOS VM is reachable.

[1] https://review.opendev.org/c/openstack/kayobe/+/897260
[2] https://review.opendev.org/c/openstack/tenks/+/736708

(cherry picked from commit 4fa1d4982fa74283360e09a1dee3bdd919acb33d)