### PR TITLE
Detect Rocky Linux version

### DIFF
--- a/etc/kayobe/globals.yml
+++ b/etc/kayobe/globals.yml
@@ -52,7 +52,7 @@ os_distribution: "{{ lookup('pipe', '. /etc/os-release && echo $ID') | trim }}"
 # OS release. Valid options are "8-stream" when os_distribution is "centos", or
 # "8" when os_distribution is "rocky", or "focal" when os_distribution is
 # "ubuntu".
-#os_release:
+os_release: "{{ lookup('pipe', '. /etc/os-release && echo $VERSION | grep -o ^.') | trim if os_distribution == 'rocky' else omit }}"
 
 ###############################################################################
 # Ansible configuration.


### PR DESCRIPTION
In Yoga, Kayobe sets os_release to 8 when os_distribution is rocky. Since we also support Rocky Linux 9, use the version of the lab VM to set the os_release variable.