### PR TITLE
Add /etc/hosts and ssh_config entries for lab hosts

### DIFF
--- a/etc/kayobe/ansible/lab-hosts.yml
+++ b/etc/kayobe/ansible/lab-hosts.yml
@@ -1,0 +1,28 @@
+---
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Update /etc/hosts for lab entities
+      local_action:
+        module: blockinfile
+        path: /etc/hosts
+        block: |
+          {% for item in groups['overcloud'] + groups['seed'] %}
+          {{ aio_ips[item] }} {{ item }}
+          {% endfor %}
+      run_once: true
+      become: true
+
+    - name: Update ssh config for lab entities
+      local_action:
+        module: blockinfile
+        path: "{{ lookup('env','HOME') }}/.ssh/config"
+        create: true
+        mode: 0600
+        block: |
+          {% for item in groups['overcloud'] + groups['seed'] %}
+          Host {{ item }}
+              User stack
+          {% endfor %}
+      run_once: true
+

--- a/etc/kayobe/ansible/lab-hosts.yml
+++ b/etc/kayobe/ansible/lab-hosts.yml
@@ -1,21 +1,18 @@
 ---
-- hosts: all
+- hosts: localhost
   gather_facts: false
   tasks:
     - name: Update /etc/hosts for lab entities
-      local_action:
-        module: blockinfile
+      blockinfile:
         path: /etc/hosts
         block: |
           {% for item in groups['overcloud'] + groups['seed'] %}
           {{ aio_ips[item] }} {{ item }}
           {% endfor %}
-      run_once: true
       become: true
 
     - name: Update ssh config for lab entities
-      local_action:
-        module: blockinfile
+      blockinfile:
         path: "{{ lookup('env','HOME') }}/.ssh/config"
         create: true
         mode: 0600
@@ -24,5 +21,4 @@
           Host {{ item }}
               User stack
           {% endfor %}
-      run_once: true
 

--- a/etc/kayobe/hooks/overcloud-inventory-discover/post.d/01-lab-hosts.yml
+++ b/etc/kayobe/hooks/overcloud-inventory-discover/post.d/01-lab-hosts.yml
@@ -1,0 +1,1 @@
+../../../ansible/lab-hosts.yml


### PR DESCRIPTION
Set a hook to a custom playbook for lab hosts so that any newly-discovered hosts will be automatically added to hostname resolution and ssh accesses to those hosts will default to use the stack user.