### PR TITLE
Set explicit MTU on dummy/bridge lab network connections

### DIFF
--- a/configure-local-networking.sh
+++ b/configure-local-networking.sh
@@ -42,6 +42,7 @@ fi
 # Add a bridge 'braio' for the Kayobe all-in-one cloud network.
 if ! sudo ip l show braio >/dev/null 2>&1; then
   sudo ip l add braio type bridge
+  sudo ip l set braio mtu 1442
   sudo ip l set braio up
   sudo ip a add $seed_hv_ip/24 dev braio
 fi
@@ -49,6 +50,7 @@ fi
 # configuration to fail. Add a dummy interface and plug it into the bridge.
 if ! sudo ip l show dummy1 >/dev/null 2>&1; then
   sudo ip l add dummy1 type dummy
+  sudo ip l set dummy1 mtu 1442
   sudo ip l set dummy1 up
   sudo ip l set dummy1 master braio
 fi


### PR DESCRIPTION
This resolves the issue where on NetworkManager systems (RL9) the seed hypervisor host configure fails on a check on braio MTU.  The issue appears to be that a pre-existing braio is created by configure-local-networking.sh that has incorrect MTU assignment. The configuration applied by MichaelRigart.interfaces creates a second configuration set for braio, but the existing configuration takes precedence.

It may be better to use nmcli to create the braio and dummy1 interfaces in the first place.