### PR TITLE
Fix image tags use in pull-retag-push playbook

### DIFF
--- a/etc/kayobe/ansible/pull-retag-push.yml
+++ b/etc/kayobe/ansible/pull-retag-push.yml
@@ -80,7 +80,7 @@
     - name: Pull container images (may take a long time)
       become: true
       vars:
-        remote_image: "{% if docker_pull_registry != '' %}{{ docker_pull_registry }}/{% endif %}{{ docker_pull_namespace }}/{{ item }}:{{ docker_pull_tag }}-{{ kolla_base_distro }}-{{ kolla_base_distro_version }}"
+        remote_image: "{% if docker_pull_registry != '' %}{{ docker_pull_registry }}/{% endif %}{{ docker_pull_namespace }}/{{ item }}:{{ docker_pull_tag }}"
       command:
         cmd: "docker pull {{ remote_image }}"
       with_items: "{{ images }}"
@@ -88,8 +88,8 @@
     - name: Retag container images
       become: true
       vars:
-        remote_image: "{% if docker_pull_registry != '' %}{{ docker_pull_registry }}/{% endif %}{{ docker_pull_namespace }}/{{ item }}:{{ docker_pull_tag }}-{{ kolla_base_distro }}-{{ kolla_base_distro_version }}"
-        local_image: "{{ kolla_docker_registry }}/{{ kolla_docker_namespace }}/{{ item }}:{{ kolla_tag }}-{{ kolla_base_distro }}-{{ kolla_base_distro_version }}"
+        remote_image: "{% if docker_pull_registry != '' %}{{ docker_pull_registry }}/{% endif %}{{ docker_pull_namespace }}/{{ item }}:{{ docker_pull_tag }}"
+        local_image: "{{ kolla_docker_registry }}/{{ kolla_docker_namespace }}/{{ item }}:{{ kolla_tag }}"
       command:
         cmd: "docker tag {{ remote_image }} {{ local_image }}"
       with_items: "{{ images }}"
@@ -97,7 +97,7 @@
     - name: Push container images (may take a long time)
       become: true
       vars:
-        local_image: "{{ kolla_docker_registry }}/{{ kolla_docker_namespace }}/{{ item }}:{{ kolla_tag }}-{{ kolla_base_distro }}-{{ kolla_base_distro_version }}"
+        local_image: "{{ kolla_docker_registry }}/{{ kolla_docker_namespace }}/{{ item }}:{{ kolla_tag }}"
       command:
         cmd: "docker push {{ local_image }}"
       with_items: "{{ images }}"


### PR DESCRIPTION
The variables docker_pull_tag and kolla_tag already include kolla_base_distro and kolla_base_distro_version [1], so the playbook was trying to pull images with tags like 2023.2-ubuntu-jammy-ubuntu-jammy, which obviously failed.

[1] https://review.opendev.org/c/openstack/kayobe/+/869444

(cherry picked from commit c57a77788a31e3bb4e0fe4d85bb8053de65e3335)