### PR TITLE
Fix configure-local-networking script on RL9

### DIFF
--- a/configure-local-networking.sh
+++ b/configure-local-networking.sh
@@ -32,8 +32,6 @@ if $(which dnf >/dev/null 2>&1); then
 fi
 
 if $(which apt >/dev/null 2>&1); then
-    sudo apt -y install iptables
-else
     sudo apt update
     sudo apt -y install iptables
 fi


### PR DESCRIPTION
Commit dc5d16da847aaadc19ae0ebf3e50a0791536f227 inserted apt code in the wrong place, resulting in the following failure on RL9:

    sudo: apt: command not found

(cherry picked from commit 7fea79c85136421ffa5ebeab46680942d2065c42)