### PR TITLE
Pull container images from Quay.io

### DIFF
--- a/etc/kayobe/ansible/pull-retag-push.yml
+++ b/etc/kayobe/ansible/pull-retag-push.yml
@@ -9,8 +9,8 @@
     container_image_regexes: ""
     container_image_sets: "{{ seed_container_image_sets + overcloud_container_image_sets }}"
     kolla_build_log_path: "/var/log/kolla-build.log"
-    docker_pull_namespace: kolla
-    docker_pull_registry: ""
+    docker_pull_namespace: "openstack.kolla"
+    docker_pull_registry: "quay.io"
     docker_pull_tag: "{{ kolla_tag }}"
   tasks:
     - name: Set the container image sets to build if images regexes specified


### PR DESCRIPTION
Container images are only updated weekly on Docker Hub.

(cherry picked from commit b1e8999b63d886b791b31ebcf62fe77f47d281cc)