### PR TITLE
Update to latest cloud images

### DIFF
--- a/etc/kayobe/kolla/config/bifrost/bifrost.yml
+++ b/etc/kayobe/kolla/config/bifrost/bifrost.yml
@@ -5,18 +5,11 @@ download_ipa: true
 
 # Use a locally hosted cloud image.
 download_custom_deploy_image: true
-{% if os_distribution == 'centos' %}
-custom_deploy_image_upstream_url: "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20221206.0.x86_64.qcow2"
-custom_deploy_image_checksum_url: "https://cloud.centos.org/centos/9-stream/x86_64/images/CHECKSUM"
-custom_deploy_image_checksum_algorithm: "sha256"
-{% elif os_distribution == 'rocky' %}
-# NOTE(priteau): Temporarily using Rocky Linux 9.3 because 9.4 images fail to
-# boot (https://bugs.rockylinux.org/view.php?id=6832)
-custom_deploy_image_upstream_url: "https://dl.rockylinux.org/vault/rocky/9.3/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2"
-custom_deploy_image_checksum_url: "https://dl.rockylinux.org/vault/rocky/9.3/images/x86_64/CHECKSUM"
-custom_deploy_image_checksum_algorithm: "sha256"
-{% else %}
-custom_deploy_image_upstream_url: "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
-custom_deploy_image_checksum_url: "https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS"
-custom_deploy_image_checksum_algorithm: "sha256"
+upstream_deploy_image_distribution: "{{ os_distribution }}"
+upstream_deploy_image_release: "{{ os_release }}"
+
+# TODO(priteau): Remove once https://bugs.launchpad.net/bifrost/+bug/2081031 is
+# resolved.
+{% if os_distribution in ['centos', 'rocky'] %}
+custom_deploy_image_checksum_algorithm: "none"
 {% endif %}


### PR DESCRIPTION
We were pinning to old cloud images, but we should now be able to switch to the latest ones since we use UEFI by default [1].

A recent Bifrost change [2] introduced various improvements surrounding deployment images that are downloaded rather than built locally. Bifrost is now aware of how to download official images, so we only need to specify the Linux distribution and release.

However, there is a bug affecting centos/rocky which are using a different file format for checksums [3]. Disable checksum verification for these distributions until it is fixed.

[1] https://review.opendev.org/c/openstack/kayobe/+/927015
[2] https://review.opendev.org/c/openstack/bifrost/+/884888
[3] https://bugs.launchpad.net/bifrost/+bug/2081031