### PR TITLE
Use Python 3.12 on Rocky Linux 9

### DIFF
--- a/a-universe-from-nothing.sh
+++ b/a-universe-from-nothing.sh
@@ -13,6 +13,11 @@ else
     sudo apt -y install git tmux
 fi
 
+# Install Python 3.12 on Rocky Linux 9
+if $(which dnf 2>/dev/null >/dev/null); then
+    sudo dnf -y install python3.12
+fi
+
 # Disable the firewall.
 sudo systemctl is-enabled firewalld && sudo systemctl stop firewalld && sudo systemctl disable firewalld
 
@@ -32,7 +37,12 @@ cd
 [[ -d beokay ]] || git clone https://github.com/stackhpc/beokay.git -b master
 
 # Use Beokay to bootstrap your control host.
-[[ -d deployment ]] || beokay/beokay.py create --base-path ~/deployment --kayobe-repo https://opendev.org/openstack/kayobe.git --kayobe-branch master --kayobe-config-repo https://github.com/stackhpc/a-universe-from-nothing.git --kayobe-config-branch master
+if $(which dnf 2>/dev/null >/dev/null); then
+    PYTHON_ARG=" --python /usr/bin/python3.12"
+else
+    PYTHON_ARG=""
+fi
+[[ -d deployment ]] || beokay/beokay.py create --base-path ~/deployment --kayobe-repo https://opendev.org/openstack/kayobe.git --kayobe-branch master --kayobe-config-repo https://github.com/stackhpc/a-universe-from-nothing.git --kayobe-config-branch master $PYTHON_ARG
 
 # Clone the Tenks repository.
 cd ~/deployment/src


### PR DESCRIPTION
This is needed once Kayobe starts requiring Python 3.10 or above [1].
This requires support for the new --python argument of beokay [2].

[1] https://review.opendev.org/c/openstack/kayobe/+/926639
[2] https://github.com/stackhpc/beokay/pull/14