### PR TITLE
Revert seed_vm_root_image to default value

### DIFF
--- a/etc/kayobe/seed-vm.yml
+++ b/etc/kayobe/seed-vm.yml
@@ -39,9 +39,7 @@ seed_vm_vcpus: 1
 # or
 # "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20221206.0.x86_64.qcow2"
 # otherwise.
-# NOTE(priteau): Temporarily using Rocky Linux 9.3 because 9.4 images fail to
-# boot (https://bugs.rockylinux.org/view.php?id=6832)
-seed_vm_root_image: https://dl.rockylinux.org/vault/rocky/9.3/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2
+#seed_vm_root_image:
 
 # Capacity of the seed VM data volume.
 #seed_vm_data_capacity:


### PR DESCRIPTION
This should not have been hardcoded to use a Rocky Linux image.