### PR TITLE
Clone default branch of beokay

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ already logged in (e.g. ``ssh rocky@<ip>``, or ``ssh ubuntu@<ip>``).
    cd
 
    # Clone Beokay.
-   git clone https://github.com/stackhpc/beokay.git -b master
+   git clone https://github.com/stackhpc/beokay.git
 
    # Use Beokay to bootstrap your control host.
    [[ -d deployment ]] || beokay/beokay.py create --base-path ~/deployment --kayobe-repo https://opendev.org/openstack/kayobe.git --kayobe-branch master --kayobe-config-repo https://github.com/stackhpc/a-universe-from-nothing.git --kayobe-config-branch master

--- a/a-universe-from-nothing.sh
+++ b/a-universe-from-nothing.sh
@@ -34,7 +34,7 @@ echo 'Defaults	!fqdn' | sudo tee /etc/sudoers.d/no-fqdn
 cd
 
 # Clone Beokay.
-[[ -d beokay ]] || git clone https://github.com/stackhpc/beokay.git -b master
+[[ -d beokay ]] || git clone https://github.com/stackhpc/beokay.git
 
 # Use Beokay to bootstrap your control host.
 if $(which dnf 2>/dev/null >/dev/null); then


### PR DESCRIPTION
This is to have fewer occurences of ``master`` to replace when we branch.