### PR TITLE
Backport support for Tenks network persistence

### DIFF
--- a/tenks-network-on-boot.service
+++ b/tenks-network-on-boot.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Runs a script to setup tenks host networking
+After=network.target
+Wants=network-online.target
+
+[Service]
+WorkingDirectory=/home/lab/deployment/src
+ExecStart=/bin/tenks-network-setup
+Restart=no
+User=lab
+Group=root
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/tenks-network-setup
+++ b/tenks-network-setup
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source /home/lab/deployment/venvs/kayobe/bin/activate
+source /home/lab/deployment/src/kayobe-config/kayobe-env
+
+cd /home/lab/deployment/src
+
+for key in $( set | awk '{FS="="}  /^OS_/ {print $1}' ); do unset $key ; done
+export KAYOBE_CONFIG_SOURCE_PATH=/home/lab/deployment/src/kayobe-config
+export KAYOBE_VENV_PATH=/home/lab/deployment/venvs/kayobe
+export TENKS_CONFIG_PATH=/home/lab/deployment/src/kayobe-config/tenks.yml
+
+kayobe/dev/tenks-network-reboot-patch.sh ./tenks


### PR DESCRIPTION
This is a backport of this [PR#200](https://github.com/stackhpc/a-universe-from-nothing/pull/200) due to the latest deployable version of the AUFN labs being for 2024.1